### PR TITLE
change seperator from , to ;

### DIFF
--- a/src/favorites.rs
+++ b/src/favorites.rs
@@ -53,7 +53,7 @@ impl Favorites {
             Err(_) => "".to_owned(),
         };
 
-        favorites.split(", ").map(|i| i.to_owned()).collect()
+        favorites.split("; ").map(|i| i.to_owned()).collect()
     }
 
     fn store(&self, favorites: Vec<String>) {
@@ -62,7 +62,7 @@ impl Favorites {
             None => return,
         };
 
-        let favorites = favorites.join(", ");
+        let favorites = favorites.join("; ");
         self.key_file.set_string("General", "Favorites", &favorites);
 
         self.key_file


### PR DESCRIPTION
I suggest using a semicolon rather than a comma, because SBB stores some locations as such "Bern, Gäbelbach".

Maybe there is a better way, but it was such a small fix.

I know now the favorites list can get kind of creepy with lots of comma separated favourites, but for me it's still better.

Maybe being able to define aliases would be nice, but that's over my head right now :smile: 