### PR TITLE
Use journey category and number instead of name, to see bus numbers and such

### DIFF
--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -13,6 +13,8 @@ pub struct Walk {
 #[derive(Deserialize, Debug, Clone)]
 pub struct Journey {
     pub name: Option<String>,
+    pub category: String,
+    pub number: String,
     pub to: String,
 
     #[serde(rename = "passList")]

--- a/src/widgets/section.rs
+++ b/src/widgets/section.rs
@@ -55,10 +55,7 @@ impl SectionWidget {
 
     fn get_journey_text(section: &Section) -> String {
         if let Some(journey) = section.journey.as_ref() {
-            return match journey.name.as_ref() {
-                Some(name) => format!("<i>{}</i>", name),
-                None => "<i>Unknown</i>".to_string(),
-            };
+            return format!("{}{}", journey.category, journey.number);
         }
 
         if let Some(walk) = section.walk.as_ref() {


### PR DESCRIPTION
Hi! Thanks for this application! I'm using it all the time on my "Librem5".

I thought the journey name never appears to show useful information (every time I tried it was a string of numbers like 06823), but category+number is much more useful. Category says whether it is a bus, a train, a tram, or which kind of train (IC, R, S, ...). And number is really important when taking a bus because there are no platform numbers at bus stations.

Cheers!